### PR TITLE
Update dmca.json

### DIFF
--- a/dmca.json
+++ b/dmca.json
@@ -3,7 +3,7 @@
         "cracked-games",
         "exomagazinfree",
         "toonfever",
-        "derrick829"
+        "derrick829",
         "dennis567"
     ],
     "videos": [

--- a/dmca.json
+++ b/dmca.json
@@ -4,6 +4,7 @@
         "exomagazinfree",
         "toonfever",
         "derrick829"
+        "dennis567"
     ],
     "videos": [
         "sorbetzitrone/hbv4srv6",


### PR DESCRIPTION
This user published private information of politicians, journalists, etc. like phone numbers, addresses or even pictures of their passport. The illegal action caused a lot of trouble in Germans newspapers and also shades a bad light on the platform DTube as it is sometimes mentioned.
Example for articles:
- https://www.vice.com/de/article/d3bb7j/politik-leak-hacker-haben-massenweise-daten-von-stars-und-politikern-ins-internet-gestellt
- https://www.l-iz.de/Topposts/2019/01/Ein-Raetsel-Hack-User-stellt-hunderte-Privatdaten-von-Politikern-und-Promis-ins-Netz-252412