### PR TITLE
Update dmca.json

### DIFF
--- a/dmca.json
+++ b/dmca.json
@@ -11,7 +11,7 @@
         "rerez/ng5tck51",
         "doessteemitwork/89n1gkl9",
         "programsforfree/i5a50ric",
-        "bart92/iji0vv3z"
+        "bart92/iji0vv3z",
         "phusionphil/3kat85le"
     ]
 }

--- a/dmca.json
+++ b/dmca.json
@@ -12,5 +12,6 @@
         "doessteemitwork/89n1gkl9",
         "programsforfree/i5a50ric",
         "bart92/iji0vv3z"
+        "phusionphil/3kat85le"
     ]
 }


### PR DESCRIPTION
The video shows the christchurch shooting in New Zealand and throws a bad light on DTube as hosting platform.